### PR TITLE
Windows: SISLNEEDPROTOTYPES so that GO_API is used

### DIFF
--- a/include/sisl.h
+++ b/include/sisl.h
@@ -71,6 +71,8 @@
 # else
 #  define GO_API __declspec(dllimport)
 # endif // __DLL__
+# undef SISLNEEDPROTOTYPES
+# define SISLNEEDPROTOTYPES
 #else
 # define GO_API
 #endif // __BORLANDC__


### PR DESCRIPTION
On Windows, when `sisl` is compiled as a DLL, then `SISLNEEDPROTOTYPES` must be defined, to that `__declspec(dllexport)` and `__declspec(dllimport)` are actually used.
